### PR TITLE
feat: support non-schema type template names

### DIFF
--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -91,6 +91,10 @@ async def write_html_file(
         raise ValueError(f"Required @type value missing in file: {file_data.path}")
     template = jinja_env.get_template(f"{schema_type}.html")
 
+    # Map custom template name to Schema.org type
+    if mapped_schema_type := SETTINGS["TEMPLATE_SCHEMA_TYPES"].get(schema_type):
+        file_data.front_matter["@type"] = mapped_schema_type
+
     # Include non-schema variables as top-level context values, removing them from
     # front_matter
     front_matter = file_data.front_matter

--- a/blurry/settings.py
+++ b/blurry/settings.py
@@ -12,6 +12,7 @@ class Settings(TypedDict):
     BUILD_DIRECTORY_NAME: str
     CONTENT_DIRECTORY_NAME: str
     TEMPLATES_DIRECTORY_NAME: str
+    TEMPLATE_SCHEMA_TYPES: dict[str, str]
 
     DEV_HOST: str
     DEV_PORT: int
@@ -39,6 +40,7 @@ SETTINGS: Settings = {
     "USE_HTTP": False,
     "RUNSERVER": False,
     "FRONTMATTER_NON_SCHEMA_VARIABLE_PREFIX": "~",
+    "TEMPLATE_SCHEMA_TYPES": {},
 }
 
 try:

--- a/docs/blurry.toml
+++ b/docs/blurry.toml
@@ -4,8 +4,12 @@ maximum_image_width = 1200
 thumbnail_width = 285
 
 [blurry.schema_data.author]
+'@type' = 'Person'
 name = 'John Franey'
 url = 'https://johnfraney.ca'
 
 [blurry.schema_data.sourceOrganization]
 name = 'Blurry'
+
+[blurry.template_schema_types]
+ContextWebPage = 'WebPage'

--- a/docs/content/templates/syntax.md
+++ b/docs/content/templates/syntax.md
@@ -21,6 +21,7 @@ For example, for a template for a regular web page, the template should be named
 
 Some common types you might use are:
 
+* [WebSite](https://schema.org/WebSite)
 * [WebPage](https://schema.org/WebPage)
 * [AboutPage](https://schema.org/AboutPage)
 * [ContactPage](https://schema.org/ContactPage)
@@ -31,3 +32,12 @@ Some common types you might use are:
 * [SoftwareApplication](https://schema.org/SoftwareApplication)
 
 See [the "More specific Types" section of WebPage](https://schema.org/WebPage#subtypes) here for other WebPage subtypes, and [the "More specific Types" section of CreativeWork](https://schema.org/CreativeWork#subtypes) for other common content types.
+
+## Custom template names
+
+If your templates require more granularity than the Schema.org types, you can write templates with custom names and map them to Schema.org types using the `template_schema_types` setting in your [`blurry.toml` configuration file](../configuration/blurry.toml.md):
+
+```toml
+[blurry.template_schema_types]
+ContextWebPage = 'WebPage'
+```


### PR DESCRIPTION
Adds support for non-Schema.org type template names using the template_schema_types setting.

Also adds small improvements to some edited files.