### PR TITLE
fix: relative path handling in Markdown files

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -29,7 +29,7 @@ from blurry.types import is_str
 from blurry.utils import build_path_to_url
 from blurry.utils import content_path_to_url
 from blurry.utils import content_path_to_url_pathname
-from blurry.utils import convert_relative_path_in_markdown_to_relative_build_path
+from blurry.utils import convert_relative_path_in_markdown_file_to_pathname
 from blurry.utils import path_to_url_pathname
 from blurry.utils import remove_lazy_loading_from_first_image
 from blurry.utils import resolve_relative_path_in_markdown
@@ -103,7 +103,9 @@ class BlurryRenderer(mistune.HTMLRenderer):
     def link(self, text, url, title: str | None = None) -> str:
         link_is_relative = url.startswith(".")
         if link_is_relative:
-            url = convert_relative_path_in_markdown_to_relative_build_path(url)
+            url = convert_relative_path_in_markdown_file_to_pathname(
+                content_directory=CONTENT_DIR, filepath=self.filepath, relative_path=url
+            )
 
         if text is None:
             text = url

--- a/blurry/utils.py
+++ b/blurry/utils.py
@@ -30,14 +30,32 @@ def convert_content_path_to_directory_in_build(path: Path) -> Path:
     return BUILD_DIR.joinpath(path)
 
 
-def convert_relative_path_in_markdown_to_relative_build_path(relative_path: str) -> str:
-    if relative_path.startswith("./"):
-        relative_path = relative_path[2:]
+def convert_relative_path_in_markdown_file_to_pathname(
+    content_directory: Path, filepath: Path, relative_path: str
+) -> str:
+    directory = filepath.parent
+    pathname_start = directory.relative_to(content_directory)
+
+    while relative_path.startswith(prefix := "../"):
+        pathname_start = pathname_start.parent
+        relative_path = relative_path[len(prefix) :]
+    while relative_path.startswith(prefix := "./"):
+        relative_path = relative_path[len(prefix) :]
     if relative_path.endswith("index.md"):
         relative_path = relative_path.replace("index.md", "")
     elif relative_path.endswith(".md"):
         relative_path = relative_path.replace(".md", "") + "/"
-    return f"../{relative_path}"
+
+    pathname_prefix = str(pathname_start).removeprefix(".")
+
+    print(pathname_start, pathname_prefix, relative_path)
+
+    pathname = f"{pathname_prefix}/{relative_path}"
+
+    if not pathname.startswith("/"):
+        pathname = f"/{pathname}"
+
+    return pathname
 
 
 def resolve_relative_path_in_markdown(relative_path: str, markdown_file: Path) -> Path:

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,12 +8,6 @@ def tests(session):
 
 
 @nox.session(python=["3.11", "3.10"])
-def lint(session):
-    session.install("flake8", ".")
-    session.run("flake8", "blurry", "tests")
-
-
-@nox.session(python=["3.11", "3.10"])
 def typecheck(session):
     session.install("pyright", ".")
     session.run("pyright")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from blurry.settings import SETTINGS
 from blurry.types import MarkdownFileData
 from blurry.utils import content_path_to_url
 from blurry.utils import convert_content_path_to_directory_in_build
-from blurry.utils import convert_relative_path_in_markdown_to_relative_build_path
+from blurry.utils import convert_relative_path_in_markdown_file_to_pathname
 from blurry.utils import format_schema_data
 from blurry.utils import get_domain_with_scheme
 from blurry.utils import path_to_url_pathname
@@ -38,17 +38,27 @@ def test_convert_content_path_to_build_path(path_in, expected_build_path):
 
 
 @pytest.mark.parametrize(
-    "path_in, expected_html_path",
+    "partial_filepath, relative_path, expected_pathname",
     [
-        ("./cool-post.md", "../cool-post/"),
-        ("../home.md", "../../home/"),
-        ("../index.md", "../../"),
-        ("./image.png", "../image.png"),
+        ("tools/index.md", "./csv-file-combiner.md", "/tools/csv-file-combiner/"),
+        ("tools/index.md", "../contact.md", "/contact/"),
+        ("index.md", "./blog/first-post.md", "/blog/first-post/"),
+        ("index.md", "./blog/archive/old-post.md", "/blog/archive/old-post/"),
+        ("projects/secret/index.md", "../../contact.md", "/contact/"),
     ],
 )
-def test_convert_content_path_to_html_path(path_in, expected_html_path):
-    html_path = convert_relative_path_in_markdown_to_relative_build_path(path_in)
-    assert html_path == expected_html_path
+def test_convert_relative_path_in_markdown_file_to_pathname(
+    tmp_path, partial_filepath, relative_path, expected_pathname
+):
+    content_directory = tmp_path / "blog" / "content"
+    filepath = content_directory / partial_filepath
+    parent = filepath.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    filepath.touch(exist_ok=True)
+    output = convert_relative_path_in_markdown_file_to_pathname(
+        content_directory, filepath, relative_path
+    )
+    assert output == expected_pathname
 
 
 def test_sort_directory_file_data_by_date():


### PR DESCRIPTION
Fixes relative path handling in Markdown files, which wasn't always working correctly and relied on some relative path trickery. Paths are now calculated with the source file path taken into consideration

Closes #20