### PR TITLE
Fix typo in documentation so the example actually works

### DIFF
--- a/docs/content/templates/examples.md
+++ b/docs/content/templates/examples.md
@@ -31,7 +31,7 @@ Here's a simple base template with blocks for:
     <link rel="canonical"
         href="{{ url }}">
     {{ open_graph_tags|safe }}
-    {{ schema_data_tag|safe }}
+    {{ schema_type_tag|safe }}
 </head>
 <body>
     <main>{% block body %}{% endblock %}</main>


### PR DESCRIPTION
A tiny fix that may help your users getting started