### PR TITLE
feat: setting for Markdown file Jinja extension

### DIFF
--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -53,7 +53,16 @@ TEMPLATE_DIR = get_templates_directory()
 app = AsyncTyper()
 
 jinja_env = Environment(
-    loader=FileSystemLoader(TEMPLATE_DIR), autoescape=select_autoescape(["html", "xml"])
+    loader=FileSystemLoader(TEMPLATE_DIR),
+    autoescape=select_autoescape(
+        list(
+            {
+                SETTINGS["MARKDOWN_FILE_JINJA_TEMPLATE_EXTENSION"].lstrip("."),
+                "html",
+                "xml",
+            }
+        )
+    ),
 )
 
 
@@ -99,7 +108,8 @@ async def write_html_file(
             f"Required @type value missing in file or TOML front matter invalid: "
             f"{file_data.path}"
         )
-    template = jinja_env.get_template(f"{schema_type}.html")
+    template_extension = SETTINGS["MARKDOWN_FILE_JINJA_TEMPLATE_EXTENSION"]
+    template = jinja_env.get_template(f"{schema_type}{template_extension}")
 
     # Map custom template name to Schema.org type
     if mapped_schema_type := SETTINGS["TEMPLATE_SCHEMA_TYPES"].get(schema_type):

--- a/blurry/constants.py
+++ b/blurry/constants.py
@@ -2,4 +2,6 @@ from pathlib import Path
 
 ENV_VAR_PREFIX = "BLURRY_"
 
+SETTINGS_FILENAME = "blurry.toml"
+
 CURR_DIR = Path.cwd()

--- a/blurry/settings.py
+++ b/blurry/settings.py
@@ -5,12 +5,14 @@ import toml
 
 from blurry.constants import CURR_DIR
 from blurry.constants import ENV_VAR_PREFIX
+from blurry.constants import SETTINGS_FILENAME
 
 
 class Settings(TypedDict):
     AVIF_COMPRESSION_QUALITY: int
     BUILD_DIRECTORY_NAME: str
     CONTENT_DIRECTORY_NAME: str
+    MARKDOWN_FILE_JINJA_TEMPLATE_EXTENSION: str
     TEMPLATES_DIRECTORY_NAME: str
     TEMPLATE_SCHEMA_TYPES: dict[str, str]
 
@@ -36,6 +38,7 @@ SETTINGS: Settings = {
     "DOMAIN": "example.com",
     # Sizes adapted from: https://link.medium.com/UqzDeLKwyeb
     "IMAGE_WIDTHS": [360, 640, 768, 1024, 1366, 1600, 1920],
+    "MARKDOWN_FILE_JINJA_TEMPLATE_EXTENSION": ".html",
     "MAXIMUM_IMAGE_WIDTH": 1920,
     "THUMBNAIL_WIDTH": 250,
     "VIDEO_EXTENSIONS": ["mp4", "webm", "mkv"],
@@ -48,7 +51,7 @@ SETTINGS: Settings = {
 
 def update_settings():
     try:
-        blurry_config = toml.load(open("blurry.toml"))
+        blurry_config = toml.load(open(SETTINGS_FILENAME))
         user_settings = blurry_config["blurry"]
         for setting, value in user_settings.items():
             SETTINGS[setting.upper()] = value


### PR DESCRIPTION
Adds a setting to customize the Jinja template extension used for schemas referenced in Markdown front matter.

For example, now template can have an extension of ".jinja.html" rather than ".html" for better editor support.