### PR TITLE
Add stylized 'blurry' and plugin table to CLI output

### DIFF
--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -48,6 +48,15 @@ def json_converter_with_dates(item: Any) -> None | str:
         return item.strftime("%Y-%M-%D")
 
 
+print(
+    """
+.  .             
+|-.| . ..-..-.. .
+`-''-'-''  '  '-|
+              `-'
+""".strip()
+)
+
 console = Console()
 
 plugin_table = Table(show_header=True)
@@ -241,8 +250,8 @@ async def build(release=True):
                 )
             )
 
-    task_count = len(markdown_tasks) + len(non_markdown_tasks)
-    print(f"Gathered {task_count} tasks")
+    content_dir_relative = CONTENT_DIR.relative_to(Path.cwd())
+    print(f"Blurring {len(markdown_tasks)} Markdown files from: {content_dir_relative}")
 
     await asyncio.gather(*markdown_tasks)
     for non_markdown_task in non_markdown_tasks:

--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -16,17 +16,16 @@ from jinja2 import FileSystemLoader
 from jinja2 import select_autoescape
 from livereload import Server
 from rich import print
-from rich.console import Console
-from rich.table import Table
 
 from blurry.async_typer import AsyncTyper
+from blurry.cli import print_blurry_name
+from blurry.cli import print_plugin_table
 from blurry.constants import ENV_VAR_PREFIX
 from blurry.images import generate_images_for_srcset
 from blurry.markdown import convert_markdown_file_to_html
 from blurry.open_graph import open_graph_meta_tags
 from blurry.plugins import discovered_html_plugins
 from blurry.plugins import discovered_jinja_filter_plugins
-from blurry.plugins import discovered_markdown_plugins
 from blurry.settings import get_build_directory
 from blurry.settings import get_content_directory
 from blurry.settings import get_templates_directory
@@ -48,28 +47,8 @@ def json_converter_with_dates(item: Any) -> None | str:
         return item.strftime("%Y-%M-%D")
 
 
-print(
-    """
-.  .             
-|-.| . ..-..-.. .
-`-''-'-''  '  '-|
-              `-'
-""".strip()
-)
-
-console = Console()
-
-plugin_table = Table(show_header=True)
-plugin_table.add_column("Markdown Plugins")
-plugin_table.add_column("HTML Plugins")
-plugin_table.add_column("Jinja Plugins")
-plugin_table.add_row(
-    "\n".join([p.name for p in discovered_markdown_plugins]),
-    "\n".join([p.name for p in discovered_html_plugins]),
-    "\n".join([p.name for p in discovered_jinja_filter_plugins]),
-)
-
-console.print(plugin_table)
+print_blurry_name()
+print_plugin_table()
 
 
 app = AsyncTyper()

--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -16,6 +16,8 @@ from jinja2 import FileSystemLoader
 from jinja2 import select_autoescape
 from livereload import Server
 from rich import print
+from rich.console import Console
+from rich.table import Table
 
 from blurry.async_typer import AsyncTyper
 from blurry.constants import ENV_VAR_PREFIX
@@ -46,9 +48,19 @@ def json_converter_with_dates(item: Any) -> None | str:
         return item.strftime("%Y-%M-%D")
 
 
-print("Markdown plugins:", [p.name for p in discovered_markdown_plugins])
-print("HTML plugins:", [p.name for p in discovered_html_plugins])
-print("Jinja filter plugins:", [p.name for p in discovered_jinja_filter_plugins])
+console = Console()
+
+plugin_table = Table(show_header=True)
+plugin_table.add_column("Markdown Plugins")
+plugin_table.add_column("HTML Plugins")
+plugin_table.add_column("Jinja Plugins")
+plugin_table.add_row(
+    "\n".join([p.name for p in discovered_markdown_plugins]),
+    "\n".join([p.name for p in discovered_html_plugins]),
+    "\n".join([p.name for p in discovered_jinja_filter_plugins]),
+)
+
+console.print(plugin_table)
 
 
 app = AsyncTyper()

--- a/blurry/cli.py
+++ b/blurry/cli.py
@@ -1,0 +1,33 @@
+from rich.console import Console
+from rich.table import Table
+
+from blurry.plugins import discovered_html_plugins
+from blurry.plugins import discovered_jinja_filter_plugins
+from blurry.plugins import discovered_markdown_plugins
+
+console = Console()
+
+
+def print_blurry_name():
+    console.print(
+        """
+.  .             
+|-.| . ..-..-.. .
+`-''-'-''  '  '-|
+              `-'
+    """.strip()
+    )
+
+
+def print_plugin_table():
+    plugin_table = Table(show_header=True)
+    plugin_table.add_column("Markdown Plugins")
+    plugin_table.add_column("HTML Plugins")
+    plugin_table.add_column("Jinja Plugins")
+    plugin_table.add_row(
+        "\n".join([p.name for p in discovered_markdown_plugins]),
+        "\n".join([p.name for p in discovered_html_plugins]),
+        "\n".join([p.name for p in discovered_jinja_filter_plugins]),
+    )
+
+    console.print(plugin_table)


### PR DESCRIPTION
This PR adds a stylized "blurry" at the top of the CLI output for recognition, adds plugins in a table rather than printing lists, and updates the line about gathered tasks to mention Markdown files specifically. I'll likely put up a follow-up PR to add an image processing progress bar, which will be helpful because image processing happens in the background.

Before:

```
Markdown plugins:
['container', 'punctuation', 'python_code', 'python_code_in_list']
HTML plugins:
['minify_html']
Jinja filter plugins:
[]
Gathered 21 tasks
Built site in 0.102329 seconds
```

After:

```
.  .             
|-.| . ..-..-.. .
`-''-'-''  '  '-|
              `-'
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Markdown Plugins    ┃ HTML Plugins ┃ Jinja Plugins ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ container           │ minify_html  │               │
│ punctuation         │              │               │
│ python_code         │              │               │
│ python_code_in_list │              │               │
└─────────────────────┴──────────────┴───────────────┘
Blurring 17 Markdown files from: content
Built site in 0.160482 seconds
```