### PR TITLE
fix: handle image property as string or dict

### DIFF
--- a/docs/content/templates/syntax.md
+++ b/docs/content/templates/syntax.md
@@ -3,6 +3,7 @@
 name = "Templates: syntax"
 abstract = "Documentation for Blurry's template files and Jinja syntax"
 datePublished = 2023-04-09
+image = {contentUrl = "../images/schema.org-logo.png"}
 +++
 
 # Templates: syntax


### PR DESCRIPTION
Handles image schema property in Markdown front matter properly if it is an object

Closes #47

## Demo

See this page with a working image object with a `contentUrl`: https://65e4b865d2776bb58dfb3e11--blurry-docs.netlify.app/templates/syntax/