### PR TITLE
#66 Add a type attribute to the source tag for Avif images.

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -85,7 +85,7 @@ class BlurryRenderer(mistune.HTMLRenderer):
             avif_srcset = generate_srcset_string(
                 src.replace(extension, "avif"), image_widths
             )
-            source_tag = '<source srcset="{}" sizes="{}" />'.format(
+            source_tag = '<source srcset="{}" sizes="{}" type="image/avif" />'.format(
                 avif_srcset, attributes["sizes"]
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blurry-cli"
-version = "0.6.2"
+version = "0.6.2.2"
 description = "A Mistune-based static site generator for Python"
 authors = ["John Franey <franey@duck.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blurry-cli"
-version = "0.6.2.2"
+version = "0.6.2"
 description = "A Mistune-based static site generator for Python"
 authors = ["John Franey <franey@duck.com>"]
 license = "MIT"


### PR DESCRIPTION
This avoids a syntax error in the HTML