### PR TITLE
Axe code that removes lazy loading from 1st image

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -29,7 +29,6 @@ from blurry.types import is_str
 from blurry.utils import content_path_to_url
 from blurry.utils import convert_relative_path_in_markdown_file_to_pathname
 from blurry.utils import path_to_url_pathname
-from blurry.utils import remove_lazy_loading_from_first_image
 from blurry.utils import resolve_relative_path_in_markdown
 
 
@@ -177,9 +176,6 @@ def convert_markdown_file_to_html(filepath: Path) -> tuple[str, dict[str, Any]]:
 
     if not is_str(html):
         raise Exception(f"Expected html to be a string but got: {type(html)}")
-
-    # Post-process HTML
-    html = remove_lazy_loading_from_first_image(html)
 
     # Seed front_matter with schema_data from config file
     front_matter: dict[str, Any] = dict(SETTINGS.get("SCHEMA_DATA", {}))

--- a/blurry/utils.py
+++ b/blurry/utils.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from selectolax.parser import HTMLParser
-
 from blurry.settings import get_build_directory
 from blurry.settings import get_content_directory
 from blurry.settings import SETTINGS
@@ -116,19 +114,3 @@ def format_schema_data(schema_data: dict) -> dict:
     formatted_schema_data = {"@context": "https://schema.org"}
     formatted_schema_data.update(schema_data)
     return formatted_schema_data
-
-
-def remove_lazy_loading_from_first_image(html: str) -> str:
-    parser = HTMLParser(html, use_meta_tags=False)
-    if not parser.body or not parser.body.html:
-        raise Exception("Could not parse HTML")
-    first_img_tag = parser.css_first("img")
-    if not first_img_tag:
-        return html
-    updated_tag = first_img_tag
-    try:
-        del updated_tag.attrs["loading"]  # type: ignore
-        first_img_tag.replace_with(HTMLParser(updated_tag.html).body.child)  # type: ignore
-    except KeyError:
-        pass
-    return parser.body.html

--- a/docs/content/content/images.md
+++ b/docs/content/content/images.md
@@ -42,9 +42,9 @@ For more information, see [the Lighthouse documentation on image aspect ratios](
 
 ### Lazy loading
 
-Blurry adds lazy loading (`loading="lazy"`) to all images in body content *except the first image*.
+Blurry adds lazy loading (`loading="lazy"`) to all images in body content.
 
-This provides a page speed boost by waiting to load most images on a page until they're needed while preserving a main image that may appear above the fold.
+This provides a page speed boost by waiting to load most images on a page until they're needed.
 
 ### Figure caption
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from selectolax.parser import HTMLParser
 
 from blurry.settings import get_build_directory
 from blurry.settings import get_content_directory
@@ -15,7 +14,6 @@ from blurry.utils import convert_relative_path_in_markdown_file_to_pathname
 from blurry.utils import format_schema_data
 from blurry.utils import get_domain_with_scheme
 from blurry.utils import path_to_url_pathname
-from blurry.utils import remove_lazy_loading_from_first_image
 from blurry.utils import sort_directory_file_data_by_date
 
 
@@ -152,22 +150,3 @@ def test_format_schema_data():
         "@context": "https://schema.org",
         "@type": "BlogPosting",
     }
-
-
-def test_remove_lazy_loading_from_first_image():
-    html = """
-    <body>
-    <picture class="one">
-        <source src="one.avif">
-        <img src="one.png" loading="lazy">
-    </picture>
-    <picture class="two">
-        <source src="two.avif">
-        <img src="two.png" loading="lazy">
-    </picture>
-    </body>
-    """
-    updated_html = remove_lazy_loading_from_first_image(html)
-    parser = HTMLParser(updated_html)
-    assert parser.css_first("picture.one img").attributes.get("loading") is None
-    assert parser.css_first("picture.two img").attributes.get("loading") == "lazy"


### PR DESCRIPTION
This code caused an issue with the HTML output and is better suited to a plugin.

Fixes #40, albeit aggressively