### PR TITLE
fix: remove global thumbnailUrl

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -183,14 +183,12 @@ def convert_markdown_file_to_html(filepath: Path) -> tuple[str, dict[str, Any]]:
 
     # Add inferred/computed/relative values
     # https://schema.org/image
-    # https://schema.org/thumbnailUrl
     front_matter.update({"url": content_path_to_url(filepath.relative_to(CONTENT_DIR))})
     if image := front_matter.get("image"):
         image_copy = deepcopy(image)
         relative_image_path = get_relative_image_path_from_image_property(image_copy)
         image_path = resolve_relative_path_in_markdown(relative_image_path, filepath)
         front_matter["image"] = update_image_with_url(image_copy, image_path)
-        front_matter["thumbnailUrl"] = image_path_to_thumbnailUrl(image_path)
     return html, front_matter
 
 

--- a/docs/content/templates/context.md
+++ b/docs/content/templates/context.md
@@ -23,7 +23,6 @@ The template context variables are:
 | ------------------------ | ---------------------------------------------------------------------------------------------- |
 | `body`                   | an HTML string converted from Markdown                                                         |
 | `url`                    | the absolute URL for the given page                                                            |
-| `thumbnailUrl`           | a path to the thumbnail version of the `image` front matter value                              |
 | `schema_type_tag`        | a `<script type="application/ld+json">` tag containing Schema.org markup                       |
 | `open_graph_tags`        | [Open Graph](https://ogp.me/) meta tags, like `<meta property="og:title" content="..." />`     |
 | `**schema_variables`     | front matter from the Markdown file, like `datePublished`                                      |


### PR DESCRIPTION
Removes global thumbnailUrl computed front matter value because not every schema type has this property