### PR TITLE
44 process jinja files in content dir

### DIFF
--- a/blurry/templates.py
+++ b/blurry/templates.py
@@ -5,6 +5,7 @@ from jinja2 import select_autoescape
 
 from blurry.plugins import discovered_jinja_extensions
 from blurry.plugins import discovered_jinja_filter_plugins
+from blurry.settings import get_content_directory
 from blurry.settings import get_templates_directory
 from blurry.settings import SETTINGS
 
@@ -14,16 +15,16 @@ def get_jinja_env() -> Environment:
     Returns a Jinja environment complete with JinjaX and any installed Jinja extensions and filters.
     """
     templates_directory = get_templates_directory()
+    content_directory = get_content_directory()
     jinja_env = Environment(
-        loader=FileSystemLoader(templates_directory),
+        loader=FileSystemLoader([content_directory, templates_directory]),
         autoescape=select_autoescape(
-            list(
+            enabled_extensions=list(
                 {
                     SETTINGS["MARKDOWN_FILE_JINJA_TEMPLATE_EXTENSION"].lstrip("."),
-                    "html",
-                    "xml",
+                    "jinja",
                 }
-            )
+            ),
         ),
         extensions=[
             jinja_extension.load() for jinja_extension in discovered_jinja_extensions

--- a/docs/content/content/dynamic.md
+++ b/docs/content/content/dynamic.md
@@ -1,0 +1,48 @@
++++
+"@type" = "WebPage"
+name = "Content: dynamic"
+abstract = "Documentation for Blurry's dynamic file handling using Jinja"
+datePublished = 2024-12-12
++++
+
+# Content: dynamic
+
+When a file in your content directory ends with `.jinja`, Blurry uses [Jinja](https://jinja.palletsprojects.com/en/stable/) to transform that file, giving you lots of flexibility to build dynamic files based on your Markdown content.
+
+Jinja files in your content directory have these context variables available:
+
+- `datetime`: a [Python `datetime` object](https://docs.python.org/3/library/datetime.html#datetime-objects)
+- `settings`: see [Configuration: settings](../configuration/settings.md) for more information
+- `file_data_by_directory`: see [Templates: context](../templates/context.md) for more information
+
+## Example
+
+For example, say we have blog posts in `/content/blog/`, and we have a `content/blog/feed.xml` file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+{% with directory="blog", datetime_format="%a, %d %b %Y %H:%M:%S %z", item_count=10 %}
+<rss version="2.0">
+<channel>
+ <title>John Franey | Blog</title>
+ <description>John Franey's blog feed</description>
+ <link>https://{{ settings.DOMAIN }}/{{ directory }}/feed.xml</link>
+ <copyright>{{ datetime.now().strftime('%Y') }} {{ settings.DOMAIN }} All rights reserved</copyright>
+ <lastBuildDate>{{ datetime.now().strftime(datetime_format).strip() }}</lastBuildDate>
+
+{% for page in (file_data_by_directory[directory])[0:item_count] %}
+ <item>
+  <title>{{ page.front_matter.headline }}</title>
+  <description>{{ page.front_matter.abstract }}</description>
+  <link>{{ page.front_matter.url }}</link>
+  <guid isPermaLink="false">{{ page.front_matter.url }}</guid>
+  <pubDate>{{ page.front_matter.datePublished.strftime(datetime_format).strip() }}</pubDate>
+ </item>
+{% endfor %}
+
+</channel>
+</rss>
+{% endwith %}
+```
+
+It will output an RSS feed with the 10 most recent entries in the `blog` directory.

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -22,6 +22,9 @@ Use your preferred Python package manager to install `blurry-cli`:
 # Poetry
 poetry add blurry-cli
 
+# uv
+uv add blurry-cli
+
 # Pipenv
 pipenv install blurry-cli
 
@@ -34,7 +37,13 @@ pip install blurry-cli
 A Blurry project uses a simple directory structure consisting of a `content` directory for [Markdown](https://daringfireball.net/projects/markdown/) site content and a `templates` directory for [Jinja](https://jinja.palletsprojects.com/en/) templates used to generate HTML pages from that Markdown content.
 Blurry outputs a built site into `dist/` by default, and this is configurable in [Blurry's settings](../configuration/settings.md).
 
-Blurry's directory structure is used as the website's navigation structure by converting `index.md` files into `index.html` files, and other Markdown files, like `about.md`, into a directory with a single `index.html` file, like `about/index.html`, which makes for clean, SEO-friendly URLs.
+Blurry's directory structure is used as the website's navigation structure, with just a little magic:
+
+- `index.md` files generate `index.html` files
+- other Markdown files, like `about.md`, generate a file like `about/index.html`, which makes for clean, SEO-friendly URLs
+- files that end with `.jinja` are processed with [Jinja](https://jinja.palletsprojects.com/en/stable/) and generate a file with the `.jinja` extension removed, like `feed.xml.jinja` -> `feed.xml`
+- images are copied and generated at multiple sizes. See [Content: Images](../content/images.md) for more information
+- other files are copied as-is
 
 For example, this Blurry project:
 
@@ -45,7 +54,9 @@ For example, this Blurry project:
 │  ├──🗎 about.md
 │  └──🗀 posts
 │     ├──🗎 index.md
+│     ├──🗎 feed.xml.jinja
 │     └──🗎 welcome.md
+├──🗎 robots.txt
 └──🗀 templates
    ├──🗎 base.html
    ├──🗎 AboutPage.html
@@ -57,8 +68,10 @@ For example, this Blurry project:
 Will result in the following URLs:
 
 - `/`
+- `/robots.txt`
 - `/about/`
 - `/posts/`
+- `/posts/feed.xml`
 - `/posts/welcome/`
 
 ## Content

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
+package-mode = false
 packages = []
 
 [tool.poetry.dependencies]
 python = "^3.10"
-blurry-cli = {path = "..", develop = true}
-blurry-plugin-blur-blurry-name = {git = "https://github.com/blurry-dev/blurry-plugin-blur-blurry-name.git"}
+blurry-cli = { path = "..", develop = true }
+blurry-plugin-blur-blurry-name = { git = "https://github.com/blurry-dev/blurry-plugin-blur-blurry-name.git" }
 
 [build-system]
 requires = ["poetry-core"]

--- a/docs/templates/base.html.jinja
+++ b/docs/templates/base.html.jinja
@@ -44,6 +44,7 @@
                         <li><a href="/content/markdown/" rel="noreferrer">Markdown</a></li>
                         <li><a href="/content/images/" rel="noreferrer">Images</a></li>
                         <li><a href="/content/videos/" rel="noreferrer">Videos</a></li>
+                        <li><a href="/content/dynamic/" rel="noreferrer">Dynamic (Jinja)</a></li>
                     </ul>
                 </li>
                 <li>Templates


### PR DESCRIPTION
Processes files ending in .jinja in the content folder, stripping the
.jinja extension.

This is useful for generating dynamic files, like RSS feeds

Closes #44 