### PR TITLE
refactor: improve performance, add progress bars

### DIFF
--- a/blurry/sitemap.py
+++ b/blurry/sitemap.py
@@ -38,9 +38,7 @@ def generate_sitemap_for_file_data_list(file_data_list: list[MarkdownFileData]) 
     return SITEMAP_TEMPLATE.format(urls=sitemap_url_content)
 
 
-async def write_sitemap_file(
-    file_data_by_directory: dict[Path, list[MarkdownFileData]]
-):
+def write_sitemap_file(file_data_by_directory: dict[Path, list[MarkdownFileData]]):
     BUILD_DIR = get_build_directory()
     file_data = []
     for file_data_list in file_data_by_directory.values():


### PR DESCRIPTION
Improves performance by:

- Copying non-Markdown file to build directory only if it doesn't exist
- Uses a ThreadPoolExecutor rather than asyncio in some places
- Starts processing files as soon as they're found during the build rather than gathering them all first
- Building only relevant Markdown/Jinja files on file change in runserver rather than triggering an entire build

Also adds transient progress bars to show build progress