### PR TITLE
fix: remove trailing slash on <img>

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -84,7 +84,7 @@ class BlurryRenderer(mistune.HTMLRenderer):
                 attributes_str = " ".join(
                     f'{name}="{value}"' for name, value in attributes.items()
                 )
-                return f"<img {attributes_str} >"
+                return f"<img {attributes_str}>"
 
             image_widths = get_widths_for_image_width(image_width)
 
@@ -103,7 +103,7 @@ class BlurryRenderer(mistune.HTMLRenderer):
 
         return (
             f"<figure>"
-            f"<picture>{source_tag}<img {attributes_str} /></picture>"
+            f"<picture>{source_tag}<img {attributes_str}></picture>"
             f'<figcaption>{attributes["alt"]}</figcaption>'
             f"</figure>"
         )

--- a/blurry/plugins/jinja_plugins/blurry_image_extension.py
+++ b/blurry/plugins/jinja_plugins/blurry_image_extension.py
@@ -73,4 +73,4 @@ class BlurryImage(StandaloneTag):
             f'{name}="{value}"' for name, value in attributes.items()
         )
 
-        return f"<img {attributes_str}/>"
+        return f"<img {attributes_str}>"

--- a/docs/content/content/images.md
+++ b/docs/content/content/images.md
@@ -61,7 +61,7 @@ Given the following Markdown syntax for an image with dimensions of 2160x1620 an
 standard Markdown processing might output:
 
 ```html
-<img alt="Screenshot of Black's playground" src="./images/black-playground.png" />
+<img alt="Screenshot of Black's playground" src="./images/black-playground.png">
 ```
 
 When configured with a maximum image width of 750px, Blurry's image plugin, by contrast, outputs:


### PR DESCRIPTION
From the W3 validator:

Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.