### PR TITLE
refactor: deploy docs site on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,14 @@
 name: Build and Deploy
+
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*.*.*'
   pull_request:
+
 permissions:
   contents: write
+
 jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.


### PR DESCRIPTION
Deploys the docs site on release rather than on merge into main so docs don't get ahead of the latest published package