### PR TITLE
docs: update CLI command docs

### DIFF
--- a/blurry/commands/clean.py
+++ b/blurry/commands/clean.py
@@ -16,4 +16,4 @@ def clean_build_directory():
     except FileNotFoundError:
         pass
 
-    print(f"Cleaned build directory: {build_directory}")
+    print(f"Cleaned build directory: {build_directory} 🧹")

--- a/docs/content/commands/build.md
+++ b/docs/content/commands/build.md
@@ -1,12 +1,12 @@
 +++
 "@type" = "WebPage"
 name = "Commands: build"
-abstract = "Documentation for Blurry's build command"
+abstract = "The build command for Blurry, a Python static site generator focused on page speed and SEO"
 datePublished = 2023-04-09
-dateModified = 2025-01-07
+dateModified = 2025-01-08
 +++
 
-# Commands: build
+# Commands: `build`
 
 ## Description
 

--- a/docs/content/commands/clean.md
+++ b/docs/content/commands/clean.md
@@ -3,10 +3,22 @@
 name = "Commands: clean"
 abstract = "The clean command for Blurry, a Python static site generator focused on page speed and SEO"
 datePublished = 2024-12-28
+dateModified = 2024-01-08
 +++
 
-# Commands: clean
+# Commands: `clean`
+
+## Description
 
 `clean` removes the build folder and all of its contents.
 
 The build folder is specified by the `build_directory_name` [setting](./../configuration/settings.md), and defaults to `./dist/`.
+
+## Usage
+
+Example usage:
+
+```shell
+$ blurry clean
+Cleaned build directory: /home/john/Code/blurry/docs/dist 🧹
+```

--- a/docs/content/commands/init.md
+++ b/docs/content/commands/init.md
@@ -1,11 +1,11 @@
 +++
 "@type" = "WebPage"
 name = "Commands: init"
-abstract = "Documentation for Blurry's build command"
-datePublished = 2025-01-07
+abstract = "The init command for Blurry, a Python static site generator focused on page speed and SEO"
+datePublished = 2025-01-08
 +++
 
-# Commands: init
+# Commands: `init`
 
 ## Description
 

--- a/docs/content/commands/runserver.md
+++ b/docs/content/commands/runserver.md
@@ -1,9 +1,9 @@
 +++
 "@type" = "WebPage"
 name = "Commands: runserver"
-abstract = "Documentation for Blurry's runserver command"
+abstract = "The runserver command for Blurry, a Python static site generator focused on page speed and SEO"
 datePublished = 2023-04-09
-dateModified = 2024-01-03
+dateModified = 2024-01-08
 +++
 
 # Commands: `runserver`


### PR DESCRIPTION
Tweak the CLI command docs to move the command name into code blocks in some cases and to add TOC entries.

Also adds a broom emoji to the clean command output for fun.