### PR TITLE
Fix workflow – removed deprecated `--sync` from `poetry install`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry config virtualenvs.create false
 
       - name: Install dependencies
-        run: poetry install --sync --no-interaction
+        run: poetry sync --no-interaction
 
       - name: Package project
         run: poetry build


### PR DESCRIPTION
Updated `.github/workflows/publish.yml` to remove the deprecated `--sync` flag from `poetry install`. The recommended approach is to use `poetry sync` instead.