### PR TITLE
fix: TOC spacing in docs when above content

### DIFF
--- a/docs/templates/assets/docs.css
+++ b/docs/templates/assets/docs.css
@@ -44,7 +44,7 @@ body>main>* {
   }
 
   body>main:has(aside#table-of-contents) {
-    grid-template-rows: auto auto 1fr;
+    grid-template-rows: auto 1fr 1fr;
     grid-template-columns: 11rem 1fr;
     grid-template-areas: "menu table-of-content" "menu body"
   }


### PR DESCRIPTION
Fixes the spacing of the TOC in docs pages when the TOC appears above the page content (small-medium screens).

Before:

![Screenshot 2025-05-02 at 15-14-15 Commands version Blurry](https://github.com/user-attachments/assets/b24e8676-4262-478b-99c5-094c33948cbc)

After:

![Screenshot 2025-05-02 at 15-14-31 Commands version Blurry](https://github.com/user-attachments/assets/ea83b8c4-10d8-4f1b-8836-8904432f3f4e)
