### PR TITLE
feat: version CLI command

### DIFF
--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -20,6 +20,7 @@ from blurry.cli import print_blurry_name
 from blurry.cli import print_plugin_table
 from blurry.commands.clean import clean_build_directory
 from blurry.commands.init import initialize_new_project
+from blurry.commands.version import print_blurry_version
 from blurry.constants import ENV_VAR_PREFIX
 from blurry.file_processors import process_non_markdown_file
 from blurry.file_processors import write_html_file
@@ -38,7 +39,7 @@ from blurry.templates import get_jinja_env
 warning_console = Console(stderr=True, style="bold yellow")
 
 
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 @app.command(name="clean")
@@ -49,6 +50,11 @@ def clean_command():
 @app.command(name="init")
 def init_command(name: str | None = None, domain: str | None = None):
     initialize_new_project(name, domain)
+
+
+@app.command(name="version")
+def version_command():
+    print_blurry_version()
 
 
 @app.async_command()

--- a/blurry/commands/version.py
+++ b/blurry/commands/version.py
@@ -1,0 +1,9 @@
+import importlib.metadata
+from rich import print
+
+
+def print_blurry_version():
+    """Prints the current Blurry version."""
+    version = importlib.metadata.version("blurry-cli")
+
+    print(f"v{version}")

--- a/docs/content/commands/version.md
+++ b/docs/content/commands/version.md
@@ -1,0 +1,23 @@
++++
+"@type" = "WebPage"
+name = "Commands: version"
+abstract = "The version command for Blurry, a Python static site generator focused on page speed and SEO"
+datePublished = 2025-05-02
++++
+
+# Commands: `version`
+
+## Description
+
+`version` prints the current version of Blurry (`blurry-cli`).
+
+This is useful for troubleshooting and logging.
+
+## Usage
+
+Example usage:
+
+```shell
+$ blurry version
+v0.15.0
+```

--- a/docs/templates/WebPage.html.jinja
+++ b/docs/templates/WebPage.html.jinja
@@ -39,6 +39,7 @@
                     <li><MenuLink href="/commands/build/" url={{ url }}><code>build</code></MenuLink></li>
                     <li><MenuLink href="/commands/runserver/" url={{ url }}><code>runserver</code></MenuLink></li>
                     <li><MenuLink href="/commands/clean/" url={{ url }}><code>clean</code></MenuLink></li>
+                    <li><MenuLink href="/commands/version/" url={{ url }}><code>version</code></MenuLink></li>
                 </ul>
             </details>
             <details open>

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,9 @@
+import importlib.metadata
+from blurry.commands.version import print_blurry_version
+
+
+def test_print_blurry_version(capsys):
+    expected_version = importlib.metadata.version("blurry-cli")
+    print_blurry_version()
+    captured = capsys.readouterr()
+    assert captured.out == f"v{expected_version}\n"


### PR DESCRIPTION
Adds version CLI command to print the currently used version of Blurry (blurry-cli)

Preview:

![image](https://github.com/user-attachments/assets/f3c7f66d-7d0b-485a-bc96-c3acb8c5c772)
