### PR TITLE
feat: fallback to WEBP if AVIF no available

### DIFF
--- a/blurry/__init__.py
+++ b/blurry/__init__.py
@@ -16,7 +16,7 @@ from rich.progress import TaskProgressColumn
 from rich.progress import TextColumn
 
 from blurry.async_typer import AsyncTyper
-from blurry.cli import print_blurry_name
+from blurry.cli import check_avif_support, print_blurry_name
 from blurry.cli import print_plugin_table
 from blurry.commands.clean import clean_build_directory
 from blurry.commands.init import initialize_new_project
@@ -66,6 +66,7 @@ async def build(release=True, clean: bool = False):
         update_settings()
         print_blurry_name()
         print_plugin_table()
+        check_avif_support(console=warning_console)
 
     build_directory = get_build_directory()
 
@@ -164,6 +165,7 @@ def runserver():
     """Starts HTTP server with live reloading."""
     print_blurry_name()
     print_plugin_table()
+    check_avif_support(console=warning_console)
 
     SETTINGS = get_settings()
     os.environ.setdefault(f"{ENV_VAR_PREFIX}BUILD_MODE", "dev")

--- a/blurry/cli.py
+++ b/blurry/cli.py
@@ -1,5 +1,6 @@
 from rich.console import Console
 from rich.table import Table
+import wand.version
 
 from blurry.plugins import discovered_html_plugins
 from blurry.plugins import discovered_jinja_extensions
@@ -35,3 +36,11 @@ def print_plugin_table():
     )
 
     console.print(plugin_table)
+
+
+def check_avif_support(console: Console):
+    if "AVIFABC" in wand.version.formats():
+        return
+    console.print(
+        "AVIF support not found. Falling back to WEBP. See https://trac.ffmpeg.org/wiki/Encode/AV1"
+    )

--- a/blurry/settings.py
+++ b/blurry/settings.py
@@ -8,7 +8,7 @@ from blurry.constants import SETTINGS_FILENAME
 
 
 class Settings(TypedDict):
-    AVIF_COMPRESSION_QUALITY: int
+    IMAGE_COMPRESSION_QUALITY: int
     BUILD_DIRECTORY_NAME: str
     CONTENT_DIRECTORY_NAME: str
     MARKDOWN_FILE_JINJA_TEMPLATE_EXTENSION: str
@@ -28,7 +28,7 @@ class Settings(TypedDict):
 
 
 SETTINGS: Settings = {
-    "AVIF_COMPRESSION_QUALITY": 90,
+    "IMAGE_COMPRESSION_QUALITY": 90,
     "BUILD_DIRECTORY_NAME": "dist",
     "CONTENT_DIRECTORY_NAME": "content",
     "TEMPLATES_DIRECTORY_NAME": "templates",

--- a/docs/content/content/images.md
+++ b/docs/content/content/images.md
@@ -23,13 +23,15 @@ These enable [responsive images](https://developer.mozilla.org/en-US/docs/Learn/
 
 This improves page speed by ensuring that devices aren't loading larger images than they can display.
 
-### AVIF
+### AVIF/WEBP
 
 Rather than rendering images as plain `<img>` elements, Blurry uses [the `<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) to support [AVIF](https://en.wikipedia.org/wiki/AVIF), while providing a fallback for browsers that do not yet support AVIF.
 
 Blurry automatically generates AVIF versions of your images, including the resized images mentioned above.
 
 This improves page speed because AVIF provides excellent image quality at smaller file sizes than other image codecs.
+
+**Note:** If AVIF support is not available, WEBP is used as a backup.
 
 ### Width & height
 


### PR DESCRIPTION
Adds a WEBP fallback if the local system can't encode images as AVIF.

Adds a message to the CLI and updates the docs accordingly

Closes #195 

Example CLI message:

```
.  .             
|-.| . ..-..-.. .
`-''-'-''  '  '-|
              `-'
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Markdown Plugins    ┃ HTML Plugins ┃ Jinja Plugins ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ container           │ minify_html  │ body_to_cards │
│ punctuation         │              │ headings      │
│ python_code         │              │ url_path      │
│ python_code_in_list │              │ blurry_image  │
└─────────────────────┴──────────────┴───────────────┘
AVIF support not found. Falling back to WEBP. See https://trac.ffmpeg.org/wiki/Encode/AV1
[I 250613 16:16:11 server:331] Serving on http://127.0.0.1:8000
```