### PR TITLE
chore: add dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
     # Group development dependencies
     groups:
       dev-dependencies:


### PR DESCRIPTION
Adds a dependency cooldown to help guard against malicious dependencies.

See: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns