### PR TITLE
feat: deprecate using alt as figcaption

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -104,12 +104,7 @@ class BlurryRenderer(mistune.HTMLRenderer):
             f'{name}="{value}"' for name, value in attributes.items()
         )
 
-        return (
-            f"<figure>"
-            f"<picture>{source_tag}<img {attributes_str}></picture>"
-            f"<figcaption>{attributes['alt']}</figcaption>"
-            f"</figure>"
-        )
+        return f"<figure><picture>{source_tag}<img {attributes_str}></picture></figure>"
 
     def link(self, text, url, title: str | None = None) -> str:
         CONTENT_DIR = get_content_directory()

--- a/docs/content/content/images.md
+++ b/docs/content/content/images.md
@@ -48,10 +48,6 @@ Blurry adds lazy loading (`loading="lazy"`) to all images in body content.
 
 This provides a page speed boost by waiting to load most images on a page until they're needed.
 
-### Figure caption
-
-Blurry adds the image's `alt` description as a figure caption (`<figcaption>`).
-
 ## Example
 
 Given the following Markdown syntax for an image with dimensions of 2160x1620 and with a `MAXIMUM_IMAGE_WIDTH` [setting](../configuration/settings.md) of 750px:
@@ -81,6 +77,5 @@ When configured with a maximum image width of 750px, Blurry's image plugin, by c
             width="2160"
             height="1620">
     </picture>
-    <figcaption>Screenshot of Black's playground</figcaption>
 </figure>
 ```


### PR DESCRIPTION
Removes code that adds a figcaption to image <figure> elements using the image's alt text.

This was a fairly significant deviation from standard Markdown output and would work better as a plugin rather than core functionality.

Closes #219