### PR TITLE
fix: Dependabot syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,3 @@ updates:
         update-types:
           - "patch"
           - "minor"
-        labels:
-          - "dependabot/dev-deps"


### PR DESCRIPTION
Removes an unexpected key from the Dependabot config