### PR TITLE
fix: Markdown assumes image is AVIF

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -89,12 +89,11 @@ class BlurryRenderer(mistune.HTMLRenderer):
             image_widths = get_widths_for_image_width(image_width)
 
             sizes = generate_sizes_string(image_widths)
-            avif_srcset = generate_srcset_string(
-                src.replace(extension, "avif"), image_widths
-            )
-            source_tag = '<source srcset="{}" sizes="{}" type="image/avif" />'.format(
-                avif_srcset, sizes
-            )
+            # Use AVIF for all remaining images, except WEBP
+            new_extension = "webp" if src.endswith(".webp") else "avif"
+            src = src.replace(extension, "avif") if new_extension != "webp" else src
+            srcset = generate_srcset_string(src, image_widths)
+            source_tag = f'<source srcset="{srcset}" sizes="{sizes}" type="image/{new_extension}" />'
 
         attributes_str = " ".join(
             f'{name}="{value}"' for name, value in attributes.items()


### PR DESCRIPTION
Fixes an assumption in the Markdown image code that assumed an image was AVIF when it could also be WEBP

Tested locally with the docs site and confirmed that the WEBP HTML is looking good:

```html
<picture>
  <source
    srcset="/images/blurry-init-screenshot-285.webp 285w, /images/blurry-init-screenshot-360.webp 360w, /images/blurry-init-screenshot-640.webp 640w, /images/blurry-init-screenshot-768.webp 768w, /images/blurry-init-screenshot-1024.webp 1024w, /images/blurry-init-screenshot-1107.webp 1107w"
    sizes="(max-width: 285px) 285px, (max-width: 360px) 360px, (max-width: 640px) 640px, (max-width: 768px) 768px, (max-width: 1024px) 1024px, 1107px"
    type="image/webp"><img alt="Screenshot of the website created with Blurry's init command"
    src="/images/blurry-init-screenshot.webp" loading="lazy" width="1107" height="318">
</picture>
```