### PR TITLE
chore: reduce image compression quality

### DIFF
--- a/blurry/settings.py
+++ b/blurry/settings.py
@@ -28,7 +28,7 @@ class Settings(TypedDict):
 
 
 SETTINGS: Settings = {
-    "IMAGE_COMPRESSION_QUALITY": 90,
+    "IMAGE_COMPRESSION_QUALITY": 55,
     "BUILD_DIRECTORY_NAME": "dist",
     "CONTENT_DIRECTORY_NAME": "content",
     "TEMPLATES_DIRECTORY_NAME": "templates",


### PR DESCRIPTION
Reduces devault image compression quality from 90 to 55. This results in smaller file sizes with minimal noticeable change in perceived quality.

See: https://github.com/wagtail/wagtail/issues/13432