### PR TITLE
fix: get event loop in async_typer

### DIFF
--- a/blurry/async_typer.py
+++ b/blurry/async_typer.py
@@ -10,7 +10,8 @@ class AsyncTyper(Typer):
             # Convert async function to synchronous
             @wraps(async_func)
             def sync_func(*_args, **_kwargs):
-                return asyncio.run(async_func(*_args, **_kwargs))
+                loop = asyncio.get_event_loop()
+                return loop.run_until_complete(async_func(*_args, **_kwargs))
 
             # Register synchronous function
             self.command(*args, **kwargs)(sync_func)


### PR DESCRIPTION
Gets the current event loop in async_typer to fix an issue where `asyncio.run()` was being called when there was already a running event loop.

Should fix #263