### PR TITLE
fix: race condition with Markdown renderer

### DIFF
--- a/blurry/markdown/__init__.py
+++ b/blurry/markdown/__init__.py
@@ -101,7 +101,6 @@ class BlurryRenderer(mistune.HTMLRenderer):
                 return f"<img {attributes_str}>"
 
             image_widths = get_widths_for_image_width(image_width)
-
             sizes = generate_sizes_string(image_widths)
             # Use AVIF for all remaining images, except WEBP
             new_extension = "webp" if src.endswith(".webp") else "avif"
@@ -155,25 +154,28 @@ def is_blurry_renderer(
     return isinstance(renderer, BlurryRenderer)
 
 
-renderer = BlurryRenderer(escape=False)
-markdown = mistune.Markdown(
-    renderer,
-    # Ignoring types because the renderer is expecting markdown: Markdown rather than md: Markdown
-    plugins=[  # type: ignore
-        abbr,
-        def_list,
-        footnotes,
-        strikethrough,
-        table,
-        task_lists,
-        url,
-    ]
-    + [plugin.load() for plugin in discovered_markdown_plugins],
-)
+def get_markdown_instance():
+    renderer = BlurryRenderer(escape=False)
+    markdown = mistune.Markdown(
+        renderer,
+        # Ignoring types because the renderer is expecting markdown: Markdown rather than md: Markdown
+        plugins=[  # type: ignore
+            abbr,
+            def_list,
+            footnotes,
+            strikethrough,
+            table,
+            task_lists,
+            url,
+        ]
+        + [plugin.load() for plugin in discovered_markdown_plugins],
+    )
+    return markdown
 
 
 def convert_markdown_file_to_html(filepath: Path) -> tuple[str, dict[str, Any]]:
     CONTENT_DIR = get_content_directory()
+    markdown = get_markdown_instance()
     if not markdown.renderer:
         raise Exception("Blurry markdown renderer not set on Mistune Markdown instance")
 

--- a/tests/test_markdown_renderer.py
+++ b/tests/test_markdown_renderer.py
@@ -1,4 +1,4 @@
-from blurry.markdown import markdown
+from blurry.markdown import get_markdown_instance
 
 MARKDOWN_WITH_HEADINGS = """
 # Home
@@ -23,6 +23,8 @@ Now we're nesting.
 
 Look! A section!
 """
+
+markdown = get_markdown_instance()
 
 
 def test_renderer_headings():


### PR DESCRIPTION
Fixes a race condition caused by using the same Markdown renderer in parallel. This led to relative images in Markdown files having incorrect paths because the were computed with a different Markdown filepath